### PR TITLE
Add app to cram

### DIFF
--- a/.cram/packageinfo
+++ b/.cram/packageinfo
@@ -1,0 +1,1 @@
+{"name": "atlas", "type": "SIOC"}

--- a/configure/RELEASE
+++ b/configure/RELEASE
@@ -30,12 +30,12 @@
 #SNCSEQ = $(MODULES)/seq-ver
 
 # EPICS_BASE should appear last so earlier modules can override stuff:
-EPICS_BASE = $(BASE_SITE_TOP)/$(EPICS_BASE_VER)
+EPICS_BASE = $(BASE_SITE_TOP)/$(BASE_MODULE_VERSION)
 
 #############################################
 # Module versions
 #############################################
-IOCADMIN_MODULE_VERSION = R3.1.16-1.3.3
+IOCADMIN_MODULE_VERSION = R3.1.16-1.3.2
 AUTOSAVE_MODULE_VERSION = R5.8-2.1.0
 
 #############################################


### PR DESCRIPTION
Add application to cram so it can be pushed easily to production
Change environment variable in configure/RELEASE to BASE_MODULE_VER to match AD RELEASE_SITE, which is created with eco
Change IOC Admin module version to one that is installed in AD /afs space